### PR TITLE
Add meta/main.yml for compatibility with Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,32 @@
+---
+galaxy_info:
+  author: Sofiane Medjkoune
+  description: Simple role to install binary goss file
+  license: MIT
+  min_ansible_version: 1.9
+
+  github_branch: master
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+        - 9
+    - name: Debian
+      versions:
+        - wheezy
+        - jessie
+        - stretch
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+
+  galaxy_tags:
+    - mono
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.


### PR DESCRIPTION
Importing these rules through Ansible Galaxy is currently not possible as the repo is lacking `meta/main.yml`, which this PR adds.

I added the meta data to the best of my knowledge, and from looking at other `main.yml`s I assume that `EL` is the platform used to describe CentOS, but could be wrong.
Also, @Nani-o please let me know which versions of ansible are supported.